### PR TITLE
define allowedToFail Settings for ember-try config

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -36,6 +36,7 @@ module.exports = {
     },
     {
       name: 'ember-beta',
+      allowedToFail: false,
       bower: {
         dependencies: {
           'ember': 'components/ember#beta'
@@ -47,6 +48,7 @@ module.exports = {
     },
     {
       name: 'ember-canary',
+      allowedToFail: true,
       bower: {
         dependencies: {
           'ember': 'components/ember#canary'


### PR DESCRIPTION
Right now, I'm just thinking Canary should be allowed to fail, but `beta` might justify it at some points, too.