### PR TITLE
Lower specificity of base styles

### DIFF
--- a/vendor/styles/ember-ticketfly-accordion.css
+++ b/vendor/styles/ember-ticketfly-accordion.css
@@ -4,7 +4,7 @@
   contain: layout;
 }
 
-.tfa-accordion .tfa-panel .tfa-panel-tab {
+.tfa-accordion .tfa-panel-tab {
   width: 100%;
   border: none;
   font-size: inherit;
@@ -22,6 +22,6 @@
   text-align: unset;
 }
 
-.tfa-accordion .tfa-panel .tfa-panel-body {
+.tfa-accordion .tfa-panel-body {
   overflow: hidden;
 }


### PR DESCRIPTION
`.tfa-accordion` ensures that we keep everything under a namespace. But from there, we should try to keep our selector specificity low, as these are meant to be fully customizable. 