### PR TITLE
Remove default width setting on accordion

### DIFF
--- a/vendor/styles/ember-ticketfly-accordion.css
+++ b/vendor/styles/ember-ticketfly-accordion.css
@@ -1,5 +1,4 @@
 .tfa-accordion {
-  width: 100%;
   position: relative;
   contain: layout;
 }


### PR DESCRIPTION
There doesn't seem to be any benefit to defaulting to this here. I'd rather leave it untouched.